### PR TITLE
Changes to make the suffix added to lb pool name configurable, other usecases

### DIFF
--- a/healthcheck.go
+++ b/healthcheck.go
@@ -25,8 +25,8 @@ func healthcheck(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "Failed to reach metadata server", http.StatusInternalServerError)
 	} else {
 		// 2) test provider
-		ok, err := provider.TestConnection()
-		if !ok {
+		err := provider.TestConnection()
+		if err != nil {
 			logrus.Errorf("Healthcheck failed: unable to reach a provider, error:%v", err)
 			http.Error(w, "Failed to reach an external provider ", http.StatusInternalServerError)
 		} else {

--- a/model/lb.go
+++ b/model/lb.go
@@ -2,7 +2,7 @@ package model
 
 type LBConfig struct {
 	LBEndpoint   string
-	LBTargetName string
+	LBTargetPoolName string
 	LBTargets    []LBTarget
 }
 

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.2
 MAINTAINER Rancher Labs, Inc.
 RUN apk add --update ca-certificates 
 
-ENV EXT_DNS_RELEASE v0.1.0
+ENV EXT_LB_RELEASE v0.1.0
 ADD external-lb /usr/bin/external-lb
 
 

--- a/providers/external_lb_provider.go
+++ b/providers/external_lb_provider.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"fmt"
-	//"github.com/Sirupsen/logrus"
 	"github.com/rancher/external-lb/model"
 )
 
@@ -12,7 +11,7 @@ type Provider interface {
 	RemoveLBConfig(config model.LBConfig) error
 	UpdateLBConfig(config model.LBConfig) error
 	GetLBConfigs() ([]model.LBConfig, error)
-	TestConnection() (bool, error)
+	TestConnection() error
 }
 
 var (
@@ -31,7 +30,7 @@ func RegisterProvider(name string, provider Provider) error {
 		providers = make(map[string]Provider)
 	}
 	if _, exists := providers[name]; exists {
-		return fmt.Errorf("provider already registered")
+		return fmt.Errorf("provider %s already registered", name)
 	}
 	providers[name] = provider
 	return nil


### PR DESCRIPTION
Changes to make the suffix to lb pool name configurable

Some minor code changes after initial review.

Fixed following usecase:
usecase 1)
Service s1 <--> vip1
And also Service s2 <--> vip1
Then Service s2 is skipped and not configured on f5

usecase 2)
Service s1 <--> vip1
Then user removed vip from s1 and then puts Service s2 <--> vip1
Then we remove the f5 config for s1 and add the config for s2.
