### PR TITLE
f5 does not error if virtual server does not exist, instead check for nil object

### DIFF
--- a/providers/f5/f5_bigip.go
+++ b/providers/f5/f5_bigip.go
@@ -59,9 +59,9 @@ func (*F5BigIPHandler) GetName() string {
 
 func (*F5BigIPHandler) AddLBConfig(config model.LBConfig) error {
 
-	_, err := client.GetVirtualServer(config.LBEndpoint)
-	if err != nil {
-		logrus.Errorf("f5 AddLBConfig: Error getting f5 virtual server: %v\n", err)
+	vServer, err := client.GetVirtualServer(config.LBEndpoint)
+	if err != nil || vServer == nil {
+		logrus.Errorf("f5 AddLBConfig: Error getting f5 virtual server, cannot add the config: %v\n", err)
 		return err
 	} else {
 		//virtualserver exists, add nodes and pool


### PR DESCRIPTION
If an invalid virtual server name is provided to the service label 'io.rancher.service.external_lb_endpoint' then the LB record configuration should error out.

f5 does not error out if an invalid virtualServer name is used. Instead it returns a null response. We need to check for nil object and error out.

https://github.com/rancher/rancher/issues/4550
