### PR TITLE
Add environment UUID to rancher suffix added on LB targets

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"ImportPath": "github.com/rancher/go-rancher-metadata/metadata",
-			"Rev": "3336d4004ef4ad0809bf7131124a74b90f5bfa40"
+			"Rev": "abd61bf46372e5f25921d716005940017916c091"
 		},
 		{
 			"ImportPath": "github.com/scottdware/go-bigip",

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/metadata.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/metadata.go
@@ -123,6 +123,19 @@ func (m *Client) GetServices() ([]Service, error) {
 	return services, nil
 }
 
+func (m *Client) GetStacks() ([]Stack, error) {
+	resp, err := m.SendRequest("/stacks")
+	var stacks []Stack
+	if err != nil {
+		return stacks, err
+	}
+
+	if err = json.Unmarshal(resp, &stacks); err != nil {
+		return stacks, err
+	}
+	return stacks, nil
+}
+
 func (m *Client) GetContainers() ([]Container, error) {
 	resp, err := m.SendRequest("/containers")
 	var containers []Container

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/types.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/types.go
@@ -2,6 +2,7 @@ package metadata
 
 type Stack struct {
 	EnvironmentName string    `json:"environment_name"`
+	EnvironmentUUID string    `json:"environment_uuid"`
 	Name            string    `json:"name"`
 	Services        []Service `json:"services"`
 }
@@ -40,9 +41,10 @@ type Container struct {
 }
 
 type Host struct {
-	Name    string            `json:"name"`
-	AgentIP string            `json:"agent_ip"`
-	HostId  int               `json:"host_id"`
-	Labels  map[string]string `json:"labels"`
-	UUID    string            `json:"uuid"`
+	Name     string            `json:"name"`
+	AgentIP  string            `json:"agent_ip"`
+	HostId   int               `json:"host_id"`
+	Labels   map[string]string `json:"labels"`
+	UUID     string            `json:"uuid"`
+	Hostname string            `json:"hostname"`
 }

--- a/external-lb.go
+++ b/external-lb.go
@@ -30,8 +30,9 @@ func getProviderLBConfigs() (map[string]model.LBConfig, error) {
 		return nil, err
 	}
 	rancherConfigs := make(map[string]model.LBConfig, len(allConfigs))
+	suffix := "_" + m.EnvironmentUUID + "_" + targetRancherSuffix
 	for _, value := range allConfigs {
-		if strings.HasSuffix(value.LBTargetPoolName, targetRancherSuffix) {
+		if strings.HasSuffix(value.LBTargetPoolName, suffix) {
 			rancherConfigs[value.LBEndpoint] = value
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -64,8 +64,8 @@ func setEnv() {
 
 	targetRancherSuffix = os.Getenv("LB_TARGET_RANCHER_SUFFIX")
 	if len(targetRancherSuffix) == 0 {
-		logrus.Info("LB_TARGET_RANCHER_SUFFIX is not set, using default suffix '_rancher.internal'")
-		targetRancherSuffix = "_rancher.internal"
+		logrus.Info("LB_TARGET_RANCHER_SUFFIX is not set, using default suffix 'rancher.internal'")
+		targetRancherSuffix = "rancher.internal"
 	}
 
 	lbEndpointServiceLabel = "io.rancher.service.external_lb_endpoint"


### PR DESCRIPTION
Changes to read environment UUID from stack metdata and then add that to  the rancher suffix added on LB pool name.

The LB targetPoolName will be now serviceName + "_" + EnvironmentUUID + "_" + RancherSuffix(provided by user while launching the template from catalog)

This fix is to make sure the external-lb instance manages the services present within the environment only and does not remove services from other environments.

https://github.com/rancher/rancher/issues/4557
