### PR TITLE
Fix image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,4 @@
-FROM ubuntu:16.04
+FROM alpine:3.4
+RUN apk add --no-cache ca-certificates 
 COPY external-lb /usr/bin/
-CMD ["external-lb"]
+ENTRYPOINT ["/usr/bin/external-lb"]


### PR DESCRIPTION
The v0.2.0 image is missing root ca certs:

> x509: failed to load system roots and no roots provided

Updated Dockerfile to:
- Add missing root ca certs
- Use alpine:3.4 base image
- Set external-lb as entrypoint
