### PR TITLE
Alters LookupInstancesByFilter so that constructing an EC2Instance do…

### DIFF
--- a/providers/elbv1/elbv1svc/ec2.go
+++ b/providers/elbv1/elbv1svc/ec2.go
@@ -79,9 +79,11 @@ func (svc *ELBClassicService) LookupInstancesByFilter(filters []*ec2.Filter) ([]
 			instance := &EC2Instance{
 				ID:               *ec2instance.InstanceId,
 				PrivateIPAddress: *ec2instance.PrivateIpAddress,
-				PublicIPAddress:  *ec2instance.PublicIpAddress,
 				SubnetID:         *ec2instance.SubnetId,
 				SecurityGroups:   securityGroups,
+			}
+			if ec2instance.PublicIpAddress != nil {
+				instance.PublicIPAddress = *ec2instance.PublicIpAddress
 			}
 			if ec2instance.VpcId != nil {
 				instance.VpcID = *ec2instance.VpcId


### PR DESCRIPTION
…es not assume ec2instance.PrivateIpAddress is non-nil. This enables the use of an ELB Classic Load Balancer with rancher hosts that do not have a public IP address (e.g. those launched in a private VPC subnet for security reasons)

This should address [this issue](https://github.com/rancher/rancher/issues/7453). 