### PR TITLE
Fixes https://github.com/rancher/rancher/issues/7453

### DIFF
--- a/providers/elbv1/elbv1svc/ec2.go
+++ b/providers/elbv1/elbv1svc/ec2.go
@@ -79,9 +79,11 @@ func (svc *ELBClassicService) LookupInstancesByFilter(filters []*ec2.Filter) ([]
 			instance := &EC2Instance{
 				ID:               *ec2instance.InstanceId,
 				PrivateIPAddress: *ec2instance.PrivateIpAddress,
-				PublicIPAddress:  *ec2instance.PublicIpAddress,
 				SubnetID:         *ec2instance.SubnetId,
 				SecurityGroups:   securityGroups,
+			}
+			if ec2instance.PublicIpAddress != nil {
+				instance.PublicIPAddress = *ec2instance.PublicIpAddress
 			}
 			if ec2instance.VpcId != nil {
 				instance.VpcID = *ec2instance.VpcId


### PR DESCRIPTION
`panic: runtime error: invalid memory address or nil pointer dereference` previously encountered when putting instances without public IPs behind an ELB Classic LB. This patch does not assume PublicIpAddress is non-nil, and only dereferences it if it is.