### PR TITLE
Add support for multiple ELBs per service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 external-lb
 ==========
-Rancher service facilitating integration of rancher with external load balancers. This service updates external LB with services created in Rancher that ask to be load balanced using an external LB. 
+Rancher service facilitating integration of rancher with external load balancers. This service updates external LB with services created in Rancher that ask to be load balanced using an external LB.
 Initial version comes with f5 BIG-IP support; but a pluggable provider model makes it easy to implement other providers later.
 
 Design
 ==========
-* The external-lb gets deployed as a Rancher service containerized app. 
+* The external-lb gets deployed as a Rancher service containerized app.
 
-* It enables any other service to be registered to external LB if the service has exposed a public port and has the label 'io.rancher.service.external_lb_endpoint'
+* It enables any other service to be registered to external LB if the service has exposed a public port and has the label 'io.rancher.service.external_lb_endpoint'.
 
-* Value of this label should be equal to the external LB endpoint that should be used for this service - example the VirtualServer Name for f5 BIG-IP
+* Value of this label should be equal to the external LB endpoint that should be used for this service - example the VirtualServer Name for f5 BIG-IP. It is possible to provide multiple values separated by comma (",") in case you want different external LBs route traffic to the same service.
 
 * The external-lb service will fetch info from rancher-metadata server at a periodic interval, then compare it with the data returned by the LB provider, and propagate the changes to the LB provider.
 

--- a/providers/elbv1/README.md
+++ b/providers/elbv1/README.md
@@ -11,7 +11,7 @@ This provider keeps pre-existing Classic Load Balancers updated with the EC2 ins
 
 1. Deploy the stack for this provider from the Rancher Catalog
 2. Using the AWS Console create a Classic ELB load balancer with one or more listeners and configure it according to your applications requirements. Configure the listener(s) with an "instance protocol" matching that of your application as well as the "instance port" that your Rancher service will expose to the hosts.
-3. Create or update your service to expose one or multiple host ports that match the configuration of your ELB listener(s). Then add the service label `io.rancher.service.external_lb.endpoint` using as value the name of the previously created ELB load balancer.
+3. Create or update your service to expose one or multiple host ports that match the configuration of your ELB listener(s). Then add the service label `io.rancher.service.external_lb.endpoint` using as value the name of the previously created ELB load balancer. You can provide multiple names separated by comma (",") in case you want different ELBs route traffic to the same service.
 
 Environment Variables
 ==========


### PR DESCRIPTION
One of the scenarios is to have series of ELBs take care of HTTPS -> HTTP for different domains and route traffic to single entrypoint (service) within the rancher (LB, traefik, etc.), which will do domain, path, etc. based business on its own.