### PR TITLE
https://github.com/rancher/rancher/issues/12189

### DIFF
--- a/README.build
+++ b/README.build
@@ -1,0 +1,5 @@
+NOTE: make package target not working for me for some reason..
+manual workaround:
+make build
+cd package && cp ../bin/external-lb .
+docker build -t chessracer/external-lb .

--- a/README.build
+++ b/README.build
@@ -1,5 +1,0 @@
-NOTE: make package target not working for me for some reason..
-manual workaround:
-make build
-cd package && cp ../bin/external-lb .
-docker build -t chessracer/external-lb .

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Design
 
 * The external-lb service will fetch info from rancher-metadata server at a periodic interval, then compare it with the data returned by the LB provider, and propagate the changes to the LB provider.
 
+Environment Variables
+==========
+
+The following environment variables are used to configure global options.
+
+| Variable | Description | Default value |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| POLL_INTERVAL | Value in milliseconds to check for rancher metadata updates | `1000` |
+| FORCE_UPDATE_INTERVAL | Value in minutes to force a resource poll. Increasing this value may be required if you run into api limits enforced by your cloud providor | `1` |
+
 Contact
 ========
 For bugs, questions, comments, corrections, suggestions, etc., open an issue in

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"time"
+	"strconv"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/rancher/external-lb/metadata"
@@ -36,6 +37,9 @@ var (
 
 	targetPoolSuffix        string
 	metadataLBConfigsCached = make(map[string]model.LBConfig)
+
+	forceUpdateInterval float64
+	i string
 )
 
 func setEnv() {
@@ -44,9 +48,15 @@ func setEnv() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	forceUpdateInterval := os.Getenv(EnvVarForceUpdateInterval)
-	if forceUpdateInterval == "" {
-		forceUpdateInterval = 1
+	i = os.Getenv(EnvVarForceUpdateInterval)
+	if i == "" {
+		i = "1"
+	}
+
+	var err error
+	forceUpdateInterval, err = strconv.ParseFloat(i, 64)
+	if err != nil {
+		logrus.Fatalf("Failed to initialize forceUpateInterval: %v", err)
 	}
 
 	if *logFile != "" {
@@ -62,7 +72,6 @@ func setEnv() {
 	}
 
 	// initialize metadata client
-	var err error
 	m, err = metadata.NewMetadataClient(*metadataAddress)
 	if err != nil {
 		logrus.Fatalf("Failed to initialize Rancher metadata client: %v", err)

--- a/main.go
+++ b/main.go
@@ -20,7 +20,8 @@ import (
 const (
 	pollInterval = 1000
 	// if metadata wasn't updated in 1 min, force update would be executed
-	forceUpdateInterval = 1
+	//forceUpdateInterval = 1
+	EnvVarForceUpdateInterval = "FORCE_UPDATE_INTERVAL"
 )
 
 var (
@@ -41,6 +42,11 @@ func setEnv() {
 	flag.Parse()
 	if *debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	forceUpdateInterval := os.Getenv(EnvVarForceUpdateInterval)
+	if forceUpdateInterval == "" {
+		forceUpdateInterval = 1
 	}
 
 	if *logFile != "" {

--- a/main.go
+++ b/main.go
@@ -19,8 +19,12 @@ import (
 )
 
 const (
-	EnvVarPollInterval        = "POLL_INTERVAL"
-	EnvVarForceUpdateInterval = "FORCE_UPDATE_INTERVAL"
+	DefaultPollInterval          = "1000"
+	DefaultForceUpdateInterval   = "1"
+	DefaultLBTargetRancherSuffix = "rancher.internal"
+	EnvVarPollInterval           = "POLL_INTERVAL"
+	EnvVarForceUpdateInterval    = "FORCE_UPDATE_INTERVAL"
+	EnvVarLBTargetRancherSuffix  = "LB_TARGET_RANCHER_SUFFIX"
 )
 
 var (
@@ -53,8 +57,8 @@ func setEnv() {
 	// initialize polling and forceUpdate intervals
 	i = os.Getenv(EnvVarForceUpdateInterval)
 	if i == "" {
-		logrus.Info(EnvVarForceUpdateInterval + " is not set, using default value '1'")
-		i = "1"
+		logrus.Info(EnvVarForceUpdateInterval + " is not set, using default value " + DefaultForceUpdateInterval)
+		i = DefaultForceUpdateInterval
 	}
 
 	// if metadata wasn't updated in 1 min, force update would be executed
@@ -65,8 +69,8 @@ func setEnv() {
 
 	p = os.Getenv(EnvVarPollInterval)
 	if p == "" {
-		logrus.Info(EnvVarPollInterval + " is not set, using default value '1000'")
-		p = "1000"
+		logrus.Info(EnvVarPollInterval + " is not set, using default value " + DefaultPollInterval)
+		p = DefaultPollInterval
 	}
 
 	pollInterval, err = strconv.ParseFloat(i, 64)
@@ -104,10 +108,10 @@ func setEnv() {
 		logrus.Fatalf("Failed to initialize provider '%s': %v", *providerName, err)
 	}
 
-	targetPoolSuffix = os.Getenv("LB_TARGET_RANCHER_SUFFIX")
+	targetPoolSuffix = os.Getenv(EnvVarLBTargetRancherSuffix)
 	if len(targetPoolSuffix) == 0 {
-		logrus.Info("LB_TARGET_RANCHER_SUFFIX is not set, using default suffix 'rancher.internal'")
-		targetPoolSuffix = "rancher.internal"
+		logrus.Info(EnvVarLBTargetRancherSuffix + " is not set, using default suffix " + DefaultLBTargetRancherSuffix)
+		targetPoolSuffix = DefaultLBTargetRancherSuffix
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/rancher/external-lb/metadata"
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EnvVarPollInterval = "POLL_INTERVAL"
+	EnvVarPollInterval        = "POLL_INTERVAL"
 	EnvVarForceUpdateInterval = "FORCE_UPDATE_INTERVAL"
 )
 
@@ -37,9 +37,9 @@ var (
 	metadataLBConfigsCached = make(map[string]model.LBConfig)
 
 	forceUpdateInterval float64
-	pollInterval float64
-	p string
-	i string
+	pollInterval        float64
+	p                   string
+	i                   string
 )
 
 func setEnv() {
@@ -73,7 +73,6 @@ func setEnv() {
 	if err != nil {
 		logrus.Fatalf("Failed to initialize pollInterval: %v", err)
 	}
-
 
 	if *logFile != "" {
 		if output, err := os.OpenFile(*logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666); err != nil {

--- a/main.go
+++ b/main.go
@@ -19,9 +19,7 @@ import (
 )
 
 const (
-	pollInterval = 1000
-	// if metadata wasn't updated in 1 min, force update would be executed
-	//forceUpdateInterval = 1
+	EnvVarPollInterval = "POLL_INTERVAL"
 	EnvVarForceUpdateInterval = "FORCE_UPDATE_INTERVAL"
 )
 
@@ -39,6 +37,8 @@ var (
 	metadataLBConfigsCached = make(map[string]model.LBConfig)
 
 	forceUpdateInterval float64
+	pollInterval float64
+	p string
 	i string
 )
 
@@ -48,16 +48,32 @@ func setEnv() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
+	var err error
+
+	// initialize polling and forceUpdate intervals
 	i = os.Getenv(EnvVarForceUpdateInterval)
 	if i == "" {
+		logrus.Info(EnvVarForceUpdateInterval + " is not set, using default value '1'")
 		i = "1"
 	}
 
-	var err error
+	// if metadata wasn't updated in 1 min, force update would be executed
 	forceUpdateInterval, err = strconv.ParseFloat(i, 64)
 	if err != nil {
-		logrus.Fatalf("Failed to initialize forceUpateInterval: %v", err)
+		logrus.Fatalf("Failed to initialize forceUpdateInterval: %v", err)
 	}
+
+	p = os.Getenv(EnvVarPollInterval)
+	if p == "" {
+		logrus.Info(EnvVarPollInterval + " is not set, using default value '1000'")
+		p = "1000"
+	}
+
+	pollInterval, err = strconv.ParseFloat(i, 64)
+	if err != nil {
+		logrus.Fatalf("Failed to initialize pollInterval: %v", err)
+	}
+
 
 	if *logFile != "" {
 		if output, err := os.OpenFile(*logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666); err != nil {


### PR DESCRIPTION
The forceUpdateInterval (default 1 min) results in an AWS SDK call; we were running into `RequestLimitExceeded: Request limit exceeded` errors when we exceeded ~15 of these guys across various environments.  This PR leaves the defaults for forceUpdateInterval and pollInterval unchanged, while allowing user overrides via env vars. 