### PR TITLE
Replaced ModifyVirtualServer to PatchVirtualServer function on f5 provider

### DIFF
--- a/providers/f5/f5_bigip.go
+++ b/providers/f5/f5_bigip.go
@@ -132,7 +132,7 @@ func (p *F5BigIPProvider) AddLBConfig(config model.LBConfig) (string, error) {
 		updatedVs := bigip.VirtualServer{}
 		updatedVs.Pool = poolName
 
-		err = p.client.ModifyVirtualServer(config.LBEndpoint, &updatedVs)
+		err = p.client.PatchVirtualServer(config.LBEndpoint, &updatedVs)
 		if err != nil {
 			logrus.Errorf("f5 AddLBConfig: Error modifying virtual server: %v\n", err)
 			return "", err
@@ -193,7 +193,7 @@ func (p *F5BigIPProvider) RemoveLBConfig(config model.LBConfig) error {
 	updatedVs := bigip.VirtualServer{}
 	updatedVs.Pool = "None"
 
-	err = p.client.ModifyVirtualServer(config.LBEndpoint, &updatedVs)
+	err = p.client.PatchVirtualServer(config.LBEndpoint, &updatedVs)
 
 	if err != nil {
 		logrus.Errorf("f5 RemoveLBConfig: Error modifying virtual server: %v\n", err)

--- a/trash.conf
+++ b/trash.conf
@@ -6,7 +6,7 @@ github.com/gorilla/websocket a69d25be2fe2923a97c2af6849b2f52426f68fc0
 github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/rancher/go-rancher/client 37c17e456a2d6dce279f54ee2f957797d30a20dc
 github.com/rancher/go-rancher-metadata/metadata 1e18111ea0df2484398d7c96bb21b6f27f975311
-github.com/scottdware/go-bigip 182a9ab858c4c3c1cd41ce598bc78bcff3dbfbab
+github.com/scottdware/go-bigip 385f55ff46011b0e9ecf6398011d959b715bfcf2
 github.com/Sirupsen/logrus 3ec0642a7fb6488f65b06f9040adc67e3990296a
 golang.org/x/sys/unix 30de6d19a3bd89a5f38ae4028e23aaa5582648af
 github.com/denverdino/aliyungo 45d9aa8

--- a/vendor/github.com/scottdware/go-bigip/ltm.go
+++ b/vendor/github.com/scottdware/go-bigip/ltm.go
@@ -539,6 +539,14 @@ type VirtualServer struct {
 	Rules            []string  `json:"rules,omitempty"`
 	Profiles         []Profile `json:"profiles,omitempty"`
 	Policies         []string  `json:"policies,omitempty"`
+	Metadata         []Metadata `json:"metadata,omitempty"`
+}
+
+// Metadata are key/value pairs of arbitrary metadata
+type Metadata struct {
+	Name string `json:"name"`
+	Persist bool `json:"persist,string"`
+	Value string `json:"value"`
 }
 
 // VirtualAddresses contains a list of all virtual addresses on the BIG-IP system.
@@ -1816,9 +1824,15 @@ func (b *BigIP) DeleteVirtualServer(name string) error {
 }
 
 // ModifyVirtualServer allows you to change any attribute of a virtual server. Fields that
-// can be modified are referenced in the VirtualServer struct.
+// can be modified are referenced in the VirtualServer struct. Set all the attributes.
 func (b *BigIP) ModifyVirtualServer(name string, config *VirtualServer) error {
 	return b.put(config, uriLtm, uriVirtual, name)
+}
+
+// PatchVirtualServer allows you to change any attribute of a virtual server. Fields that
+// can be modified are referenced in the VirtualServer struct. Sets only the attributes specified.
+func (b *BigIP) PatchVirtualServer(name string, config *VirtualServer) error {
+	return b.patch(config, uriLtm, uriVirtual, name)
 }
 
 // VirtualServerProfiles gets the profiles currently associated with a virtual server.
@@ -1883,9 +1897,15 @@ func (b *BigIP) VirtualAddressStatus(vaddr, state string) error {
 }
 
 // ModifyVirtualAddress allows you to change any attribute of a virtual address. Fields that
-// can be modified are referenced in the VirtualAddress struct.
+// can be modified are referenced in the VirtualAddress struct. Sets all the attributes.
 func (b *BigIP) ModifyVirtualAddress(vaddr string, config *VirtualAddress) error {
 	return b.put(config, uriLtm, uriVirtualAddress, vaddr)
+}
+
+// PatchVirtualAddress allows you to change any attribute of a virtual address. Fields that
+// can be modified are referenced in the VirtualAddress struct. Sets only the attributes specified.
+func (b *BigIP) PatchVirtualAddress(vaddr string, config *VirtualAddress) error {
+	return b.patch(config, uriLtm, uriVirtualAddress, vaddr)
 }
 
 func (b *BigIP) DeleteVirtualAddress(vaddr string) error {

--- a/vendor/github.com/scottdware/go-bigip/net.go
+++ b/vendor/github.com/scottdware/go-bigip/net.go
@@ -162,6 +162,35 @@ type RouteDomain struct {
 	Vlans      []string `json:"vlans,omitempty"`
 }
 
+// BGPInstances contains a list of every BGP instance on the BIG-IP system.
+type BGPInstances struct {
+	BGPInstances []BGPInstance `json:"items"`
+}
+
+// BGPInstance contains information about each individual BGP instance. You can use all
+// of these fields when modifying a BGP instance.
+type BGPInstance struct {
+	Name       string `json:"name,omitempty"`
+	Partition  string `json:"partition,omitempty"`
+	FullPath   string `json:"fullPath,omitempty"`
+	Generation int    `json:"generation,omitempty"`
+	LocalAS    int    `json:"localAs,omitempty"`
+}
+
+// BGPNeighbors contains a list of BGP neighbors of a BGP instance on the BIG-IP system.
+type BGPNeighbors struct {
+	BGPNeighbors []BGPNeighbor `json:"items"`
+}
+
+// BGPNeighbor contains information about each individual BGP neighbor. You can use all
+// of these fields when modifying a BGP neighbor.
+type BGPNeighbor struct {
+	Name       string `json:"name,omitempty"`
+	FullPath   string `json:"fullPath,omitempty"`
+	Generation int    `json:"generation,omitempty"`
+	RemoteAS   int    `json:"remoteAs,omitempty"`
+}
+
 const (
 	uriNet         = "net"
 	uriInterface   = "interface"
@@ -170,6 +199,9 @@ const (
 	uriVlan        = "vlan"
 	uriRoute       = "route"
 	uriRouteDomain = "route-domain"
+	uriRouting     = "routing"
+	uriBGP         = "bgp"
+	uriNeighbor    = "neighbor"
 )
 
 // Interfaces returns a list of interfaces.
@@ -407,4 +439,106 @@ func (b *BigIP) DeleteRouteDomain(name string) error {
 // can be modified are referenced in the RouteDomain struct.
 func (b *BigIP) ModifyRouteDomain(name string, config *RouteDomain) error {
 	return b.put(config, uriNet, uriRouteDomain, name)
+}
+
+// BGPInstances returns a list of BGP instances.
+func (b *BigIP) BGPInstances() (*BGPInstances, error) {
+	var bgpInstances BGPInstances
+	err, _ := b.getForEntity(&bgpInstances, uriNet, uriRouting, uriBGP)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bgpInstances, nil
+}
+
+// CreateBGPInstance adds a new BGP instance to the BIG-IP system.
+func (b *BigIP) CreateBGPInstance(name string, localAS int) error {
+	config := &BGPInstance{
+		Name:    name,
+		LocalAS: localAS,
+	}
+
+	return b.post(config, uriNet, uriRouting, uriBGP)
+}
+
+// AddBGPInstance adds a new BGP instance to the BIG-IP system.
+func (b *BigIP) AddBGPInstance(config *BGPInstance) error {
+	return b.post(config, uriNet, uriRouting, uriBGP)
+}
+
+// GetBGPInstance gets a BGP instance.
+func (b *BigIP) GetBGPInstance(name string) (*BGPInstance, error) {
+	var bgpInstance BGPInstance
+	err, ok := b.getForEntity(&bgpInstance, uriNet, uriRouting, uriBGP, name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	return &bgpInstance, nil
+}
+
+// DeleteBGPInstance removes a BGP instance.
+func (b *BigIP) DeleteBGPInstance(name string) error {
+	return b.delete(uriNet, uriRouting, uriBGP, name)
+}
+
+// ModifyBGPInstance allows you to change any attribute of a BGP instance. Fields that
+// can be modified are referenced in the BGPInstance struct.
+func (b *BigIP) ModifyBGPInstance(name string, config *BGPInstance) error {
+	return b.put(config, uriNet, uriRouting, uriBGP, name)
+}
+
+// BGPNeighbors returns a list of BGP neighbors of a BGP instance.
+func (b *BigIP) BGPNeighbors(instance string) (*BGPNeighbors, error) {
+	var bgpNeighbors BGPNeighbors
+	err, _ := b.getForEntity(&bgpNeighbors, uriNet, uriRouting, uriBGP, instance, uriNeighbor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bgpNeighbors, nil
+}
+
+// CreateBGPNeighbor adds a new BGP neigbhor to a BGP instance in the BIG-IP system.
+func (b *BigIP) CreateBGPNeighbor(instance, name string, remoteAS int) error {
+	config := &BGPNeighbor{
+		Name:     name,
+		RemoteAS: remoteAS,
+	}
+
+	return b.post(config, uriNet, uriRouting, uriBGP, instance, uriNeighbor)
+}
+
+// AddBGPNeighbor adds a new BGP neighbor to a BGP instance in the BIG-IP system.
+func (b *BigIP) AddBGPNeighbor(instance string, config *BGPNeighbor) error {
+	return b.post(config, uriNet, uriRouting, uriBGP, instance, uriNeighbor)
+}
+
+// GetBGPNeighbor gets a BGP neighbor of a BGP instance.
+func (b *BigIP) GetBGPNeighbor(instance, name string) (*BGPNeighbor, error) {
+	var bgpNeighbor BGPNeighbor
+	err, ok := b.getForEntity(&bgpNeighbor, uriNet, uriRouting, uriBGP, instance, uriNeighbor, name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	return &bgpNeighbor, nil
+}
+
+// DeleteBGPNeighbor removes a BGP neighbor from a BGP instance.
+func (b *BigIP) DeleteBGPNeighbor(instance, name string) error {
+	return b.delete(uriNet, uriRouting, uriBGP, instance, uriNeighbor, name)
+}
+
+// ModifyBGPNeighbor allows you to change any attribute of a BGP neighbor of a BGP instance.
+// Fields that can be modified are referenced in the BGPNeighbor struct.
+func (b *BigIP) ModifyBGPNeighbor(instance, name string, config *BGPNeighbor) error {
+	return b.put(config, uriNet, uriRouting, uriBGP, instance, uriNeighbor, name)
 }


### PR DESCRIPTION
- Replaced ModifyVirtualServer to PatchVirtualServer function on f5 provider
- Updated trash.conf and vendor github.com/scottdware/go-bigip files.

Solves issue https://github.com/rancher/rancher/issues/13269