### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/providers/avi/avisession.go
+++ b/providers/avi/avisession.go
@@ -289,7 +289,7 @@ func (avi *AviSession) Delete(uri string) (interface{}, error) {
 	return avi.rest_request_interface_response("DELETE", uri, nil)
 }
 
-// get issues a GET request against the avi REST API.
+// GetCollection gets issues a GET request against the avi REST API.
 func (avi *AviSession) GetCollection(uri string) (AviCollectionResult, error) {
 	var result AviCollectionResult
 	res, rerror := avi.rest_request("GET", uri, nil)

--- a/providers/avi/avivs.go
+++ b/providers/avi/avivs.go
@@ -51,7 +51,7 @@ func InitAviSession(cfg *AviConfig) (*AviSession, error) {
 	return aviSession, err
 }
 
-// checks if pool exists: returns the pool, else some error
+// CheckPoolExists checks if pool exists: returns the pool, else some error
 func (p *AviProvider) CheckPoolExists(poolName string) (bool, map[string]interface{}, error) {
 	var resp map[string]interface{}
 

--- a/providers/elbv1/elbv1svc/ec2.go
+++ b/providers/elbv1/elbv1svc/ec2.go
@@ -112,7 +112,7 @@ func (svc *ELBClassicService) DescribeSubnets(ids []string) ([]*ec2.Subnet, erro
 	return resp.Subnets, nil
 }
 
-// AzSubnets returns a map of all availability zones in the service's
+// GetAzSubnets returns a map of all availability zones in the service's
 // VPC as keys and the ID of one active subnet in that zone as value.
 func (svc *ELBClassicService) GetAzSubnets() (map[string]string, error) {
 	params := &ec2.DescribeSubnetsInput{

--- a/providers/elbv1/elbv1svc/elb_classic.go
+++ b/providers/elbv1/elbv1svc/elb_classic.go
@@ -17,7 +17,7 @@ const (
 	Unknown      = "Unknown"
 )
 
-// GetLoadBalancers returns the LoadBalancerDescription struct
+// GetLoadBalancerByName returns the LoadBalancerDescription struct
 // for the specified load balancer or nil if it was not found.
 func (svc *ELBClassicService) GetLoadBalancerByName(name string) (*elb.LoadBalancerDescription, error) {
 	logrus.Debugf("GetLoadBalancerByName => %s", name)
@@ -94,7 +94,7 @@ func (svc *ELBClassicService) AddLBTags(loadBalancerName string, tags map[string
 	return nil
 }
 
-// RemoveLBTags adds the specified tags to the specified load balancer.
+// RemoveLBTag adds the specified tags to the specified load balancer.
 func (svc *ELBClassicService) RemoveLBTag(loadBalancerName string, tagKey string) error {
 	logrus.Debugf("RemoveLBTag => name: %s, tagKey %s", loadBalancerName, tagKey)
 	params := &elb.RemoveTagsInput{
@@ -273,7 +273,7 @@ func (svc *ELBClassicService) RegisterInstances(loadBalancerName string, instanc
 	return nil
 }
 
-// DergisterInstances deregisters the specified EC2
+// DeregisterInstances deregisters the specified EC2
 // instances from the specified load balancer.
 func (svc *ELBClassicService) DeregisterInstances(loadBalancerName string, instanceIds []string) error {
 	logrus.Debugf("DeregisterInstances => name: %s instances: %v",


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?